### PR TITLE
Add iCloud syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Next
+* Added support for iCloud syncing via `Defaults.syncKeys([])`. [@StevenMagdy](https://github.com/StevenMagdy)
 
 ### 5.3.0 (2021-02-24)
 * Renamed `OptionalType.empty` to `OptionalType.__swifty_empty`. Also removed the `OptionalType.wrapped` since it wasn't used in the framework anymore. Please note that this still shouldn't be something you rely on tho, we're gonna explore ways to remove the public `OptionalType` in a future releases. [@sunshinejr](https://github.com/sunshinejr)

--- a/Sources/Defaults+Syncing.swift
+++ b/Sources/Defaults+Syncing.swift
@@ -28,16 +28,12 @@ public extension DefaultsAdapter {
 
     func startSyncing(for keyPaths: PartialKeyPath<KeyStore>...) {
         let rawKeys = keyPaths.map { keyStore[keyPath: $0] }.compactMap { $0 as? RawKeyRepresentable }.map { $0._key }
-        rawKeys.forEach {
-            syncer.syncedKeys.insert($0)
-        }
+        syncer.syncedKeys.formUnion(rawKeys)
     }
 
     func stopSyncing(for keyPaths: PartialKeyPath<KeyStore>...) {
         let rawKeys = keyPaths.map { keyStore[keyPath: $0] }.compactMap { $0 as? RawKeyRepresentable }.map { $0._key }
-        rawKeys.forEach {
-            syncer.syncedKeys.remove($0)
-        }
+        syncer.syncedKeys.subtract(rawKeys)
     }
 
     func stopSyncingAll() {

--- a/Sources/Defaults+Syncing.swift
+++ b/Sources/Defaults+Syncing.swift
@@ -25,10 +25,25 @@
 #if !os(Linux)
 
 public extension DefaultsAdapter {
-    func syncKeys(_ keys: [(KeyStore) -> RawKeyRepresentable]) {
-        let keys = Set(keys.map { $0(keyStore)._key })
-        syncer.syncedKeys = keys
+
+    func startSyncing(for keyPaths: PartialKeyPath<KeyStore>...) {
+        let rawKeys = keyPaths.map { keyStore[keyPath: $0] }.compactMap { $0 as? RawKeyRepresentable }.map { $0._key }
+        rawKeys.forEach {
+            syncer.syncedKeys.insert($0)
+        }
     }
+
+    func stopSyncing(for keyPaths: PartialKeyPath<KeyStore>...) {
+        let rawKeys = keyPaths.map { keyStore[keyPath: $0] }.compactMap { $0 as? RawKeyRepresentable }.map { $0._key }
+        rawKeys.forEach {
+            syncer.syncedKeys.remove($0)
+        }
+    }
+
+    func stopSyncingAll() {
+        syncer.syncedKeys = []
+    }
+
 }
 
 #endif

--- a/Sources/Defaults+Syncing.swift
+++ b/Sources/Defaults+Syncing.swift
@@ -36,6 +36,10 @@ public extension DefaultsAdapter {
         syncer.syncedKeys.subtract(rawKeys)
     }
 
+    func forceSync() {
+        syncer.forceSync()
+    }
+
     func stopSyncingAll() {
         syncer.syncedKeys = []
     }

--- a/Sources/Defaults+Syncing.swift
+++ b/Sources/Defaults+Syncing.swift
@@ -25,11 +25,9 @@
 #if !os(Linux)
 
 public extension DefaultsAdapter {
-
-    @available(macOS 10.11, iOS 9.0, *)
-    func syncKeys(_ keyPath: [(KeyStore) -> RawKeyRepresentable]) {
-        let keys = Set(keyPath.map { $0(keyStore)._key })
-        DefaultsSyncer.shared.syncedKeys = keys
+    func syncKeys(_ keys: [(KeyStore) -> RawKeyRepresentable]) {
+        let keys = Set(keys.map { $0(keyStore)._key })
+        syncer.syncedKeys = keys
     }
 }
 

--- a/Sources/Defaults+Syncing.swift
+++ b/Sources/Defaults+Syncing.swift
@@ -1,0 +1,36 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#if !os(Linux)
+
+public extension DefaultsAdapter {
+
+    @available(macOS 10.11, iOS 9.0, *)
+    func syncKeys(_ keyPath: [(KeyStore) -> RawKeyRepresentable]) {
+        let keys = Set(keyPath.map { $0(keyStore)._key })
+        DefaultsSyncer.shared.syncedKeys = keys
+    }
+}
+
+#endif

--- a/Sources/Defaults+Syncing.swift
+++ b/Sources/Defaults+Syncing.swift
@@ -22,7 +22,7 @@
 // SOFTWARE.
 //
 
-#if !os(Linux)
+#if !os(Linux) && !os(watchOS)
 
 public extension DefaultsAdapter {
 

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -85,7 +85,7 @@ internal extension UserDefaults {
 
 // MARK: - NSUbiquitousKeyValueStore
 
-extension NSUbiquitousKeyValueStore {
+public extension NSUbiquitousKeyValueStore {
 
     /// Returns `true` if `key` exists
     func hasKey<T>(_ key: DefaultsKey<T>) -> Bool {
@@ -98,10 +98,8 @@ extension NSUbiquitousKeyValueStore {
         synchronize()
     }
 
-    /// Removes all keys and values from user defaults
+    /// Removes all keys and values from iCloud
     /// Use with caution!
-    /// - Note: This method only removes keys on the receiver `NSUbiquitousKeyValueStore` object.
-    ///         System-defined keys will still be present afterwards.
     func removeAll() {
         for (key, _) in dictionaryRepresentation {
             removeObject(forKey: key)

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -83,6 +83,8 @@ internal extension UserDefaults {
     }
 }
 
+#if !os(Linux) && !os(watchOS)
+
 // MARK: - NSUbiquitousKeyValueStore
 
 public extension NSUbiquitousKeyValueStore {
@@ -107,3 +109,5 @@ public extension NSUbiquitousKeyValueStore {
         synchronize()
     }
 }
+
+#endif

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -34,6 +34,8 @@ import Foundation
 
 public var Defaults = DefaultsAdapter<DefaultsKeys>(defaults: .standard, keyStore: .init())
 
+// MARK: - UserDefaults
+
 public extension UserDefaults {
 
     /// Returns `true` if `key` exists
@@ -78,5 +80,32 @@ internal extension UserDefaults {
         } catch {
             assertionFailure("Failure encoding encodable of type \(T.self): \(error.localizedDescription)")
         }
+    }
+}
+
+// MARK: - NSUbiquitousKeyValueStore
+
+extension NSUbiquitousKeyValueStore {
+
+    /// Returns `true` if `key` exists
+    func hasKey<T>(_ key: DefaultsKey<T>) -> Bool {
+        return object(forKey: key._key) != nil
+    }
+
+    /// Removes value for `key`
+    func remove<T>(_ key: DefaultsKey<T>) {
+        removeObject(forKey: key._key)
+        synchronize()
+    }
+
+    /// Removes all keys and values from user defaults
+    /// Use with caution!
+    /// - Note: This method only removes keys on the receiver `NSUbiquitousKeyValueStore` object.
+    ///         System-defined keys will still be present afterwards.
+    func removeAll() {
+        for (key, _) in dictionaryRepresentation {
+            removeObject(forKey: key)
+        }
+        synchronize()
     }
 }

--- a/Sources/DefaultsAdapter.swift
+++ b/Sources/DefaultsAdapter.swift
@@ -45,12 +45,18 @@ public struct DefaultsAdapter<KeyStore: DefaultsKeyStore> {
 
     public let defaults: UserDefaults
     public let keyStore: KeyStore
+
+    #if !os(Linux) && !os(watchOS)
     internal let syncer: DefaultsSyncer
+    #endif
 
     public init(defaults: UserDefaults, keyStore: KeyStore) {
         self.defaults = defaults
         self.keyStore = keyStore
+
+        #if !os(Linux) && !os(watchOS)
         self.syncer = DefaultsSyncer(defaults: defaults)
+        #endif
     }
 
     @available(*, unavailable)

--- a/Sources/DefaultsAdapter.swift
+++ b/Sources/DefaultsAdapter.swift
@@ -45,10 +45,12 @@ public struct DefaultsAdapter<KeyStore: DefaultsKeyStore> {
 
     public let defaults: UserDefaults
     public let keyStore: KeyStore
+    internal let syncer: DefaultsSyncer
 
     public init(defaults: UserDefaults, keyStore: KeyStore) {
         self.defaults = defaults
         self.keyStore = keyStore
+        self.syncer = DefaultsSyncer(defaults: defaults)
     }
 
     @available(*, unavailable)

--- a/Sources/DefaultsAdapter.swift
+++ b/Sources/DefaultsAdapter.swift
@@ -48,6 +48,12 @@ public struct DefaultsAdapter<KeyStore: DefaultsKeyStore> {
 
     #if !os(Linux) && !os(watchOS)
     internal let syncer: DefaultsSyncer
+
+    internal init(defaults: UserDefaults, keyStore: KeyStore, remoteStore: RemoteStore) {
+        self.defaults = defaults
+        self.keyStore = keyStore
+        self.syncer = DefaultsSyncer(defaults: defaults, remoteStore: remoteStore)
+    }
     #endif
 
     public init(defaults: UserDefaults, keyStore: KeyStore) {
@@ -55,7 +61,7 @@ public struct DefaultsAdapter<KeyStore: DefaultsKeyStore> {
         self.keyStore = keyStore
 
         #if !os(Linux) && !os(watchOS)
-        self.syncer = DefaultsSyncer(defaults: defaults)
+        self.syncer = DefaultsSyncer(defaults: defaults, remoteStore: NSUbiquitousKeyValueStore.default)
         #endif
     }
 

--- a/Sources/DefaultsKey.swift
+++ b/Sources/DefaultsKey.swift
@@ -24,11 +24,15 @@
 
 import Foundation
 
+public protocol RawKeyRepresentable {
+  var _key: String { get }
+}
+
 // MARK: - Static keys
 
 /// Specialize with value type
 /// and pass key name to the initializer to create a key.
-public struct DefaultsKey<ValueType: DefaultsSerializable> {
+public struct DefaultsKey<ValueType: DefaultsSerializable>: RawKeyRepresentable {
 
     public let _key: String
     public let defaultValue: ValueType.T?

--- a/Sources/DefaultsKey.swift
+++ b/Sources/DefaultsKey.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public protocol RawKeyRepresentable {
+internal protocol RawKeyRepresentable {
   var _key: String { get }
 }
 

--- a/Sources/DefaultsSyncer.swift
+++ b/Sources/DefaultsSyncer.swift
@@ -35,7 +35,6 @@ internal class DefaultsSyncer {
 
     init(defaults: UserDefaults) {
         self.defaults = defaults
-        iCloudDefaultsDidUpdate()
         NotificationCenter.default.addSafeObserver(self,
                                                    selector: #selector(iCloudDefaultsDidUpdate),
                                                    name: NSUbiquitousKeyValueStore.didChangeExternallyNotification)

--- a/Sources/DefaultsSyncer.swift
+++ b/Sources/DefaultsSyncer.swift
@@ -29,9 +29,7 @@ internal class DefaultsSyncer {
 
     let defaults: UserDefaults
 
-    var syncedKeys = Set<String>() {
-        didSet { iCloudDefaultsDidUpdate() }
-    }
+    var syncedKeys = Set<String>()
 
     init(defaults: UserDefaults) {
         self.defaults = defaults
@@ -41,6 +39,11 @@ internal class DefaultsSyncer {
         NotificationCenter.default.addSafeObserver(self,
                                                    selector: #selector(localDefaultsDidUpdate),
                                                    name: UserDefaults.didChangeNotification)
+    }
+
+    internal func forceSync() {
+        iCloudDefaultsDidUpdate()
+        localDefaultsDidUpdate()
     }
 
     @objc

--- a/Sources/DefaultsSyncer.swift
+++ b/Sources/DefaultsSyncer.swift
@@ -1,0 +1,93 @@
+//
+// SwiftyUserDefaults
+//
+// Copyright (c) 2015-present Radosław Pietruszewski, Łukasz Mróz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#if !os(Linux)
+
+import Foundation
+
+// The OS requirment just to ignore dealing with unregistering notifications
+@available(macOS 10.11, iOS 9.0, *)
+internal class DefaultsSyncer {
+
+    var syncedKeys = Set<String>() {
+        didSet { syncFromICloud() }
+    }
+
+    let defaults: UserDefaults
+
+    private init(defaults: UserDefaults) {
+        self.defaults = defaults
+        syncFromICloud()
+        NotificationCenter.default.addSafeObserver(self,
+                                                   selector: #selector(iCloudDefaultsDidUpdate),
+                                                   name: NSUbiquitousKeyValueStore.didChangeExternallyNotification)
+        NotificationCenter.default.addSafeObserver(self,
+                                                   selector: #selector(localDefaultsDidUpdate),
+                                                   name: UserDefaults.didChangeNotification)
+    }
+
+    @objc
+    private func iCloudDefaultsDidUpdate() {
+        NotificationCenter.default.removeObserver(self, name: UserDefaults.didChangeNotification, object: nil)
+
+        syncFromICloud()
+
+        NotificationCenter.default.addSafeObserver(self,
+                                                   selector: #selector(localDefaultsDidUpdate),
+                                                   name: UserDefaults.didChangeNotification)
+    }
+
+    private func syncFromICloud() {
+        let allICloudKeys = Set(NSUbiquitousKeyValueStore.default.dictionaryRepresentation.keys)
+        let updatedSyncedKeys = allICloudKeys.filter { syncedKeys.contains($0) }
+        updatedSyncedKeys.forEach { key in
+            let iCloudValue = NSUbiquitousKeyValueStore.default.object(forKey: key)
+            defaults.set(iCloudValue, forKey: key)
+        }
+    }
+
+    @objc
+    private func localDefaultsDidUpdate() {
+        syncedKeys.forEach { key in
+            let localValue = defaults.object(forKey: key)
+            NSUbiquitousKeyValueStore.default.set(localValue, forKey: key)
+        }
+        // request upload to ICloud
+        NSUbiquitousKeyValueStore.default.synchronize()
+    }
+
+}
+
+@available(macOS 10.11, iOS 9.0, *)
+internal extension DefaultsSyncer {
+    static let shared = DefaultsSyncer(defaults: Defaults.defaults)
+}
+
+private extension NotificationCenter {
+    func addSafeObserver(_ observer: Any, selector aSelector: Selector, name aName: NSNotification.Name, object anObject: Any? = nil) {
+        removeObserver(observer, name: aName, object: anObject)
+        addObserver(observer, selector: aSelector, name: aName, object: anObject)
+    }
+}
+
+#endif

--- a/Sources/DefaultsSyncer.swift
+++ b/Sources/DefaultsSyncer.swift
@@ -21,7 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-#if !os(Linux)
+#if !os(Linux) && !os(watchOS)
 
 import Foundation
 

--- a/SwiftyUserDefaults.xcodeproj/project.pbxproj
+++ b/SwiftyUserDefaults.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		9FA427F1D84703CE8EC6CD38 /* Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE155E06F856DFEF78FD63F7 /* Defaults.swift */; };
 		A3CAE6734DDE8FD952CE2CF2 /* Defaults+Subscripts.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF92C9F82ABF7807D4D4DDDD /* Defaults+Subscripts.swift */; };
 		ACE14E08E7B3EECD55B932B3 /* Defaults+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D8980553F1615D4ACB4AA43 /* Defaults+Dictionary.swift */; };
+		B01ABE9223E4798200E5E003 /* DefaultsSyncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B01ABE9123E4798200E5E003 /* DefaultsSyncer.swift */; };
+		B056341D23E3C5DD006D08EE /* Defaults+Syncing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B056341C23E3C5DD006D08EE /* Defaults+Syncing.swift */; };
 		B31C4E974609611EF7360E51 /* Defaults+Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8790CE5B53F91DAD51975EDC /* Defaults+Double.swift */; };
 		C1EF5E679553F49B4C163561 /* SwiftyUserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = B134969522555B348C06FD6C /* SwiftyUserDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC4CF6A63F6AA1B932D6757E /* DefaultsBridges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20EBA39F1E25782FDC1CFC36 /* DefaultsBridges.swift */; };
@@ -69,6 +71,8 @@
 		9701991125BC1345631E831E /* DefaultsObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DefaultsObserver.swift; path = Sources/DefaultsObserver.swift; sourceTree = "<group>"; };
 		A574FF49CBCEBCCEAE9BD42E /* Defaults+String.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+String.swift"; path = "Tests/SwiftyUserDefaultsTests/Built-ins/Defaults+String.swift"; sourceTree = "<group>"; };
 		A5A5BEEC51B2A01157F9965F /* Defaults+BestFroggiesEnum.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+BestFroggiesEnum.swift"; path = "Tests/SwiftyUserDefaultsTests/External types/Defaults+BestFroggiesEnum.swift"; sourceTree = "<group>"; };
+		B01ABE9123E4798200E5E003 /* DefaultsSyncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DefaultsSyncer.swift; path = Sources/DefaultsSyncer.swift; sourceTree = "<group>"; };
+		B056341C23E3C5DD006D08EE /* Defaults+Syncing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Defaults+Syncing.swift"; path = "Sources/Defaults+Syncing.swift"; sourceTree = "<group>"; };
 		B134969522555B348C06FD6C /* SwiftyUserDefaults.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SwiftyUserDefaults.h; path = Sources/SwiftyUserDefaults.h; sourceTree = "<group>"; };
 		BF92C9F82ABF7807D4D4DDDD /* Defaults+Subscripts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Defaults+Subscripts.swift"; path = "Sources/Defaults+Subscripts.swift"; sourceTree = "<group>"; };
 		CB55DC75BF69CEA7DB03750E /* BuiltIns.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BuiltIns.swift; path = Sources/BuiltIns.swift; sourceTree = "<group>"; };
@@ -131,6 +135,8 @@
 				85096B65E07A3BC7F856F0D1 /* OptionalType.swift */,
 				858E15CF231FEC2F00DC1418 /* PropertyWrappers.swift */,
 				B134969522555B348C06FD6C /* SwiftyUserDefaults.h */,
+				B056341C23E3C5DD006D08EE /* Defaults+Syncing.swift */,
+				B01ABE9123E4798200E5E003 /* DefaultsSyncer.swift */,
 			);
 			name = Sources;
 			sourceTree = "<group>";
@@ -165,7 +171,9 @@
 				1A0E1BA11455E9E44F192EAA /* Sources */,
 				C14BA19AA073B0F4B6ED9A3D /* Tests */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		5BF9A4C7B374362259AAD1B0 /* Built-ins */ = {
 			isa = PBXGroup;
@@ -357,8 +365,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				858E15D0231FEC2F00DC1418 /* PropertyWrappers.swift in Sources */,
+				B01ABE9223E4798200E5E003 /* DefaultsSyncer.swift in Sources */,
 				D102C1011A4314AFF773DCD5 /* Defaults+StringToBool.swift in Sources */,
 				037280C1C6C68BDB8E3759E6 /* DefaultsKey.swift in Sources */,
+				B056341D23E3C5DD006D08EE /* Defaults+Syncing.swift in Sources */,
 				CC4CF6A63F6AA1B932D6757E /* DefaultsBridges.swift in Sources */,
 				ED39909122B0204E0046F502 /* DefaultsKeys.swift in Sources */,
 				A3CAE6734DDE8FD952CE2CF2 /* Defaults+Subscripts.swift in Sources */,


### PR DESCRIPTION
Adds #228 

Usage:

```swift
// Prefs.swift
extension DefaultsKeys {
  var username: DefaultsKey<String?> { return .init("username") }
  var launchCount: DefaultsKey<Int> { return .init("launchCount", defaultValue: 0) }
}

// AppDelegate.swift

func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
  Defaults.syncKeys([
    { $0.launchCount },
    { $0.username }
  ])
  return true
}

// ViewController.swift

@IBAction
func stopSyncingUsername(_ sender: UIButton) {
  Defaults.syncKeys([
    { $0.launchCount },
  ])
}
```

Obviously the worst part of this implementation is `syncKeys` syntax and that it takes an array of closures. I tried to make it accept an array of `KeyPath` or even `PartialKeyPath` but failed so this was the best alternative.
 The other approach that I could have taken is for it to be without parameters and use `Mirror` internally:
```swift
func syncKeys() {
  let keys = Mirror(reflecting: keyStore).children.compactMap { $0 as? RawKeyRepresentable }.filter { $0.isSynced }.map { $0._key }
  DefaultsSyncer.shared.syncedKeys = Set(keys)
}
```
but i don't like using `Mirror` because i feel it's very hacky

The whole implementation is not perfect but it's acceptable given the current structure.

@sunshinejr I'm willing to take another run at it if it's not acceptable for you.

Edit: the Mirror implementation does not even work because it ignores computed properties but I'm sure we can runtime-hack it to get the keys list. still not preferred. 