### PR TITLE
[Suggestion]Change from assertionFailure to fatalError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Next
 
+* Changed form assertionFailure to fatalError. [@funzin](https://github.com/funzin)
+
 ### 5.0.0 (2019-12-31)
 * 🚀
 

--- a/Sources/Defaults.swift
+++ b/Sources/Defaults.swift
@@ -70,13 +70,13 @@ internal extension UserDefaults {
     }
 
     /// Encodes passed `encodable` and saves the resulting data into the user defaults for the key `key`.
-    /// Any error encoding will result in an assertion failure.
+    /// Any error encoding will result in an fatal error.
     func set<T: Encodable>(encodable: T, forKey key: String) {
         do {
             let data = try JSONEncoder().encode(encodable)
             set(data, forKey: key)
         } catch {
-            assertionFailure("Failure encoding encodable of type \(T.self): \(error.localizedDescription)")
+            fatalError("Failure encoding encodable of type \(T.self): \(error.localizedDescription)")
         }
     }
 }


### PR DESCRIPTION
## Reference
- https://drewag.me/posts/2019/09/11/json-encoder-change-in-swift-5
- https://github.com/sunshinejr/SwiftyUserDefaults/blob/master/Sources/Defaults.swift#L75-L80


## Summary
This is sample code.
```swift
extension Int64: DefaultsSerializable {}
let int64Key = DefaultsKey<Int64>("int64Key", defaultValue: 0)


// not saved
// Defaults[key: int64Key] == 0
Defaults[key: int64Key]＝ Int64(10000)
```

When I tried to save the value with the above code, but couldn't save it with Int64.(only iOS11, iOS12)
I know that's why `JSONEncorder.encode` is failing here
ref: https://github.com/sunshinejr/SwiftyUserDefaults/blob/master/Sources/Defaults.swift#L75-L80

Especially in the case of `Carthage`, it is hard to notice because the framework is generated in the release build and **it does not crash in the `assertionFailure`**.
So I would like to change `assertionFailure` to `fatalError`.
