### PR TITLE
fix typo in a type name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ extension DefaultsKeys {
 }
 ```
 
-You can declare a `Test` struct:
+You can declare a `Settings` struct:
 ```swift
 struct Settings {
     @SwiftyUserDefault(keyPath: \.userColorScheme)


### PR DESCRIPTION
I think the "`Test`" part was a typo.