### PR TITLE
Make key string optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Define your keys!
 
 ```swift
 extension DefaultsKeys {
-    var username: DefaultsKey<String?> { .init("username") }
-    var launchCount: DefaultsKey<Int> { .init("launchCount", defaultValue: 0) }
+    var username: DefaultsKey<String?> { .init() }
+    var launchCount: DefaultsKey<Int> { .init(defaultValue: 0) }
+    var hotkeyEnabled: DefaultsKey<Bool> { .init("custom_key", defaultValue: true) }
 }
 ```
 

--- a/Sources/DefaultsKey.swift
+++ b/Sources/DefaultsKey.swift
@@ -34,7 +34,7 @@ public struct DefaultsKey<ValueType: DefaultsSerializable> {
     public let defaultValue: ValueType.T?
     internal var isOptional: Bool
 
-    public init(_ key: String, defaultValue: ValueType.T) {
+    public init(_ key: String = #function, defaultValue: ValueType.T) {
         self._key = key
         self.defaultValue = defaultValue
         self.isOptional = false
@@ -42,7 +42,7 @@ public struct DefaultsKey<ValueType: DefaultsSerializable> {
 
     // Couldn't figure out a way of how to pass a nil/none value from extension, thus this initializer.
     // Used for creating an optional key (without defaultValue)
-    private init(key: String) {
+    private init(key: String = #function) {
         self._key = key
         self.defaultValue = nil
         self.isOptional = true
@@ -56,11 +56,11 @@ public struct DefaultsKey<ValueType: DefaultsSerializable> {
 
 public extension DefaultsKey where ValueType: DefaultsSerializable, ValueType: OptionalType, ValueType.Wrapped: DefaultsSerializable {
 
-    init(_ key: String) {
+    init(_ key: String = #function) {
         self.init(key: key)
     }
 
-    init(_ key: String, defaultValue: ValueType.T) {
+    init(_ key: String = #function, defaultValue: ValueType.T) {
         self._key = key
         self.defaultValue = defaultValue
         self.isOptional = true


### PR DESCRIPTION
This PR allows us to define the key in a more comfortable way:

```swift
extension DefaultsKeys {
    // Before
    var username: DefaultsKey<String?> { .init("username") }

    // After
    var username: DefaultsKey<String?> { .init() }
}
```

I am not sure about the best way to add test cases to the existing system. Instead, I run this test locally.

```swift

import XCTest
@testable import SwiftyUserDefaults

extension DefaultsKeys {
    var username: DefaultsKey<String?> { .init() }
    var launchCount: DefaultsKey<Int> { .init(defaultValue: 0) }
    var hotkeyEnabled: DefaultsKey<Bool> { .init("hotkey", defaultValue: true) }
}

class MyTest: XCTestCase {

    func testKeys() {
        let ud = UserDefaults.standard

        Defaults.username = nil
        XCTAssertNil(ud.string(forKey: "username"))
        Defaults.username = "foo"
        XCTAssertEqual("foo", ud.string(forKey: "username"))

        Defaults.launchCount = 20
        XCTAssertEqual(20, ud.integer(forKey: "launchCount"))
        Defaults.removeAll()
        XCTAssertEqual(0, ud.integer(forKey: "launchCount"))

        XCTAssertTrue(Defaults.hotkeyEnabled)
        Defaults.hotkeyEnabled = false
        XCTAssertEqual(NSNumber(value: false), ud.object(forKey: "hotkey") as? NSNumber)
    }
}
```