### PR TITLE
Switch `DefaultsAdapter` subscript setter to `nonmutating`, which also fixes exclusive access crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Next
 
+### 5.2.0 (2021-02-23)
+* DefaultsAdapter's subscript setters are now `nonmutating`. This shouldn't change much on the client side, but it does fix the issue with simultaneous access (#241, #247). [@sunshinejr](https://github.com/sunshinejr)
+
 ### 5.1.0 (2020-12-14)
 * Increase min deployment target to iOS 9.0 due to Xcode 12 requirements [@laevandus](https://github.com/laevandus)
 

--- a/Sources/Defaults+Subscripts.swift
+++ b/Sources/Defaults+Subscripts.swift
@@ -24,60 +24,60 @@
 
 import Foundation
 
-public extension DefaultsAdapter {
+extension DefaultsAdapter {
 
-    subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T: OptionalType, T.T == T {
+    public subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T: OptionalType, T.T == T {
         get {
             return defaults[key]
         }
-        set {
+        nonmutating set {
             defaults[key] = newValue
         }
     }
 
-    subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T.T == T {
+    public subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T.T == T {
         get {
             return defaults[key]
         }
-        set {
+        nonmutating set {
             defaults[key] = newValue
         }
     }
 
-    subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T {
+    public subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T {
         get {
             return defaults[keyStore[keyPath: keyPath]]
         }
-        set {
+        nonmutating set {
             defaults[keyStore[keyPath: keyPath]] = newValue
         }
     }
 
-    subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T {
+    public subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T {
         get {
             return defaults[keyStore[keyPath: keyPath]]
         }
-        set {
+        nonmutating set {
             defaults[keyStore[keyPath: keyPath]] = newValue
         }
     }
 
     // Weird flex, but needed these two for the dynamicMemberLookup :shrug:
 
-    subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T {
+    public subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T {
         get {
             return self[keyPath]
         }
-        set {
+        nonmutating set {
             self[keyPath] = newValue
         }
     }
 
-    subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T {
+    public subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T {
         get {
             return self[keyPath]
         }
-        set {
+        nonmutating set {
             self[keyPath] = newValue
         }
     }

--- a/Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift
+++ b/Tests/SwiftyUserDefaultsTests/TestHelpers/DefaultsSerializableSpec.swift
@@ -630,6 +630,43 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(beNil())
                 }
                 #endif
+                
+                then("reference itself in the update closure without crash") {
+                    let key = DefaultsKey<Serializable?>("test")
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    var newValueReferencedDirectly: Serializable?
+                    observer = defaults.observe(key) { receivedUpdate in
+                        update = receivedUpdate
+                        newValueReferencedDirectly = defaults[key: key]
+                    }
+                    defaults[key: key] = self.customValue
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                    expect(update?.newValue).toEventually(equal(newValueReferencedDirectly))
+                }
+                
+                then("reference itself in the update closure on custom queue without crash") {
+                    let key = DefaultsKey<Serializable?>("test")
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    var newValueReferencedDirectly: Serializable?
+                    observer = defaults.observe(key) { receivedUpdate in
+                        update = receivedUpdate
+                        newValueReferencedDirectly = defaults[key: key]
+                    }
+
+                    DispatchQueue.global(qos: .utility).async {
+                        defaults[key: key] = self.customValue
+                    }
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.oldValue).toEventually(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                    expect(update?.newValue).toEventually(equal(newValueReferencedDirectly))
+                }
 
                 then("remove observer on dispose") {
                     let key = DefaultsKey<Serializable?>("test")
@@ -776,6 +813,41 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
                     expect(update?.newValue).toEventually(equal(self.defaultValue))
                 }
                 #endif
+                
+                then("reference itself in the update closure without crash") {
+                    let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    var newValueReferencedDirectly: Serializable?
+                    observer = defaults.observe(key) { receivedUpdate in
+                        update = receivedUpdate
+                        newValueReferencedDirectly = defaults[key: key]
+                    }
+                    defaults[key: key] = self.customValue
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                    expect(update?.newValue).toEventually(equal(newValueReferencedDirectly))
+                }
+                
+                then("reference itself in the update closure on custom queue without crash") {
+                    let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable?>.Update?
+                    var newValueReferencedDirectly: Serializable?
+                    observer = defaults.observe(key) { receivedUpdate in
+                        update = receivedUpdate
+                        newValueReferencedDirectly = defaults[key: key]
+                    }
+
+                    DispatchQueue.global(qos: .utility).async {
+                        defaults[key: key] = self.customValue
+                    }
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                    expect(update?.newValue).toEventually(equal(newValueReferencedDirectly))
+                }
 
                 then("remove observer on dispose") {
                     let key = DefaultsKey<Serializable?>("test", defaultValue: self.defaultValue)
@@ -889,6 +961,41 @@ extension DefaultsSerializableSpec where Serializable.T: Equatable, Serializable
 
                     expect(update?.oldValue).toEventually(equal(self.defaultValue))
                     expect(update?.newValue).toEventually(equal(self.customValue))
+                }
+                
+                then("reference itself in the update closure without crash") {
+                    let key = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable>.Update?
+                    var newValueReferencedDirectly: Serializable?
+                    observer = defaults.observe(key) { receivedUpdate in
+                        update = receivedUpdate
+                        newValueReferencedDirectly = defaults[key: key]
+                    }
+                    defaults[key: key] = self.customValue
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                    expect(update?.newValue).toEventually(equal(newValueReferencedDirectly))
+                }
+                
+                then("reference itself in the update closure on custom queue without crash") {
+                    let key = DefaultsKey<Serializable>("test", defaultValue: self.defaultValue)
+
+                    var update: DefaultsObserver<Serializable>.Update?
+                    var newValueReferencedDirectly: Serializable?
+                    observer = defaults.observe(key) { receivedUpdate in
+                        update = receivedUpdate
+                        newValueReferencedDirectly = defaults[key: key]
+                    }
+
+                    DispatchQueue.global(qos: .utility).async {
+                        defaults[key: key] = self.customValue
+                    }
+
+                    expect(update).toEventuallyNot(beNil())
+                    expect(update?.newValue).toEventually(equal(self.customValue))
+                    expect(update?.newValue).toEventually(equal(newValueReferencedDirectly))
                 }
 
                 then("remove observer on dispose") {


### PR DESCRIPTION
Fixes #241, #247. This should be released soon under 5.2.0 version.