### PR TITLE
Added `DefaultsProviding` protocol that `DefaultsAdapter` implements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 5.2.0 (2021-02-23)
 * DefaultsAdapter's subscript setters are now `nonmutating`. This shouldn't change much on the client side, but it does fix the issue with simultaneous access (#241, #247). [@sunshinejr](https://github.com/sunshinejr)
+* Added `DefaultsProviding` protocol that `DefaultsAdapter` implements. It should help with DI and creating test adapters (#268). [@sunshinejr](https://github.com/sunshinejr)
 
 ### 5.1.0 (2020-12-14)
 * Increase min deployment target to iOS 9.0 due to Xcode 12 requirements [@laevandus](https://github.com/laevandus)

--- a/Sources/Defaults+Subscripts.swift
+++ b/Sources/Defaults+Subscripts.swift
@@ -24,8 +24,18 @@
 
 import Foundation
 
-extension DefaultsAdapter {
+public protocol DefaultsProviding {
+    associatedtype KeyStore: DefaultsKeyStore
+    
+    subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T: OptionalType, T.T == T { get nonmutating set }
+    subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T.T == T { get nonmutating set }
+    subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T { get nonmutating set }
+    subscript<T: DefaultsSerializable>(keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T { get nonmutating set }
+    subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T: OptionalType, T.T == T { get nonmutating set }
+    subscript<T: DefaultsSerializable>(dynamicMember keyPath: KeyPath<KeyStore, DefaultsKey<T>>) -> T.T where T.T == T { get nonmutating set }
+}
 
+extension DefaultsAdapter: DefaultsProviding {
     public subscript<T: DefaultsSerializable>(key key: DefaultsKey<T>) -> T.T where T: OptionalType, T.T == T {
         get {
             return defaults[key]


### PR DESCRIPTION
Related #268. It should help with DI and creating test adapters.