### PR TITLE
Rename `OptionalType.empty` to `OptionalType.__swifty_empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Next
 
 ### 5.3.0 (2021-02-24)
-* Renamed `OptionalType.empty` to `OptionalType.__swifty_empty`. This shouldn't be something you rely on tho, we're gonna explore ways to remove the public `OptionalType` in a future releases. [@sunshinejr](https://github.com/sunshinejr)
+* Renamed `OptionalType.empty` to `OptionalType.__swifty_empty`. Also removed the `OptionalType.wrapped` since it wasn't used in the framework anymore. Please note that this still shouldn't be something you rely on tho, we're gonna explore ways to remove the public `OptionalType` in a future releases. [@sunshinejr](https://github.com/sunshinejr)
 
 ### 5.2.0 (2021-02-23)
 * DefaultsAdapter's subscript setters are now `nonmutating`. This shouldn't change much on the client side, but it does fix the issue with simultaneous access (#241, #247). [@sunshinejr](https://github.com/sunshinejr)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Next
 
+### 5.3.0 (2021-02-24)
+* Renamed `OptionalType.empty` to `OptionalType.__swifty_empty`. This shouldn't be something you rely on tho, we're gonna explore ways to remove the public `OptionalType` in a future releases. [@sunshinejr](https://github.com/sunshinejr)
+
 ### 5.2.0 (2021-02-23)
 * DefaultsAdapter's subscript setters are now `nonmutating`. This shouldn't change much on the client side, but it does fix the issue with simultaneous access (#241, #247). [@sunshinejr](https://github.com/sunshinejr)
 * Added `DefaultsProviding` protocol that `DefaultsAdapter` implements. It should help with DI and creating test adapters (#268). [@sunshinejr](https://github.com/sunshinejr)

--- a/Sources/Defaults+Subscripts.swift
+++ b/Sources/Defaults+Subscripts.swift
@@ -103,7 +103,7 @@ public extension UserDefaults {
             } else if let defaultValue = key.defaultValue {
                 return defaultValue
             } else {
-                return T.T.empty
+                return T.T.__swifty_empty
             }
         }
         set {

--- a/Sources/OptionalType.swift
+++ b/Sources/OptionalType.swift
@@ -28,18 +28,12 @@ protocol OptionalTypeCheck {
 
 public protocol OptionalType {
     associatedtype Wrapped
-    var wrapped: Wrapped? { get }
-
-    static var empty: Self { get }
+    
+    static var __swifty_empty: Self { get }
 }
 
 extension Optional: OptionalType, OptionalTypeCheck {
-
-    public var wrapped: Wrapped? {
-        return self
-    }
-
-    public static var empty: Optional {
+    public static var __swifty_empty: Optional {
         return nil
     }
 


### PR DESCRIPTION
Fixes #274.