### PR TITLE
Fix value upgraded from version 3

### DIFF
--- a/Sources/DefaultsBridges.swift
+++ b/Sources/DefaultsBridges.swift
@@ -240,11 +240,8 @@ public struct DefaultsCodableBridge<T: Codable>: DefaultsBridge {
     }
 
     public func get(key: String, userDefaults: UserDefaults) -> T? {
-        if let data = userDefaults.object(forKey: key) as? T {
-            return data
-        }
         guard let data = userDefaults.data(forKey: key) else {
-            return nil
+            return userDefaults.object(forKey: key) as? T
         }
         return deserialize(data)
     }

--- a/Sources/DefaultsBridges.swift
+++ b/Sources/DefaultsBridges.swift
@@ -240,6 +240,9 @@ public struct DefaultsCodableBridge<T: Codable>: DefaultsBridge {
     }
 
     public func get(key: String, userDefaults: UserDefaults) -> T? {
+        if let data = userDefaults.object(forKey: key) as? T {
+            return data
+        }
         guard let data = userDefaults.data(forKey: key) else {
             return nil
         }


### PR DESCRIPTION
Version 3 of `SwiftyUserDefaults` saved `Array<String|Int|Float|Double...>` as Array in UserDefaults, if upgrade it to version 4 or 5.x, the value will be saved as `Codable`. Then the values will be lost in the new version.