### PR TITLE
Add PrivacyInfo.xcprivacy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -16,7 +16,7 @@ func resolveDependencies() -> [Package.Dependency] {
 }
 
 func resolveTargets() -> [Target] {
-    let baseTarget = Target.target(name: "SwiftyUserDefaults", dependencies: [], path: "Sources")
+    let baseTarget = Target.target(name: "SwiftyUserDefaults", dependencies: [], path: "Sources", resources: [.process("PrivacyInfo.xcprivacy")])
     let testTarget = Target.testTarget(name: "SwiftyUserDefaultsTests", dependencies: ["SwiftyUserDefaults", "Quick", "Nimble"])
 
     return shouldTest ? [baseTarget, testTarget] : [baseTarget]

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C56D.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/SwiftyUserDefaults.podspec
+++ b/SwiftyUserDefaults.podspec
@@ -22,4 +22,5 @@ Pod::Spec.new do |s|
   s.cocoapods_version = '>= 1.4.0'  
 
   s.source_files = 'Sources/*.swift'
+  s.resource_bundles = {'SwiftyUserDefaults' => ['Sources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
This PR adds a privacy manfiest (PrivacyInfo.xcprivacy), Apple has not been mentioned [here](https://developer.apple.com/support/third-party-SDK-requirements), but this SDK is using the [User Defaults API](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api)

Additionally, since the `swift-tools-version` in Package.swift is set to 5.0, it was not possible to add resources to the target. Functions that include resources available from version 5.3, so I have updated it to 5.3. ([swift-package-manager github](https://github.com/apple/swift-package-manager/blob/8268caa411b45fde7d886c2e7fc7982ae277040c/Sources/PackageDescription/Target.swift#L882))

resolve #299 #300 

